### PR TITLE
fix: 关闭普通商店依然会触发商店刷新

### DIFF
--- a/assets/tasks/Shop.json
+++ b/assets/tasks/Shop.json
@@ -26,6 +26,9 @@
                     "pipeline_override": {
                         "ShopFreeGoodsPurchase": {
                             "enabled": true
+                        },
+                        "ShopFreeReset": {
+                            "enabled": true
                         }
                     }
                 },
@@ -33,6 +36,9 @@
                     "name": "No",
                     "pipeline_override": {
                         "ShopFreeGoodsPurchase": {
+                            "enabled": false
+                        },
+                        "ShopFreeReset": {
                             "enabled": false
                         }
                     }


### PR DESCRIPTION
修复关闭"普通商店购买免费商品并使用免费刷新次数"按钮，依然会触发ShopFreeReset的问题